### PR TITLE
Trim the date/time stamp before creating the html element.

### DIFF
--- a/last-modified-timestamp.php
+++ b/last-modified-timestamp.php
@@ -121,10 +121,12 @@ class LastModifiedTimestamp
 
 		extract( $data );
 
-		$timestamp = str_replace(
-			array( '%date%','%time%','%sep%' ),													// search
-			array( get_the_modified_date( $datef ), get_the_modified_time( $timef ), $sep ),	// replace
-			$format 																			// subject
+		$timestamp = trim(
+			str_replace(
+				array( '%date%','%time%','%sep%' ),													// search
+				array( get_the_modified_date( $datef ), get_the_modified_time( $timef ), $sep ),	// replace
+				$format 																			// subject
+			)
 		);
 
 		$timestamp = '<span class="last-modified-timestamp">' . $timestamp . '</span>';


### PR DESCRIPTION
Just in case there's some extra padding, like if the time format is just " " because someone is using the shortcode to show the day, but not the time.